### PR TITLE
Add support for bazel builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Kokoro iOS runner
 
-This repo contains a script for running iOS tests on a kokoro instance, though it can be deployed
-to any iOS testing infrastructure.
+This repo contains a script for running iOS tests on a kokoro instance.
 
-## Usage
+## Usage (xcodebuild)
 
-An example script making use of the kokoro iOS runner:
+An example script making use of the xcodebuild kokoro iOS runner:
 
 ```bash
 #!/bin/bash
@@ -22,7 +21,31 @@ git fetch
 git checkout v1.0.0
 popd
 
-./.kokoro-ios-runner/build_and_test.sh "MotionInterchange/MotionInterchange.xcodeproj" MotionInterchange "iPhone SE"
+./.kokoro-ios-runner/xcodebuild.sh "MotionInterchange/MotionInterchange.xcodeproj" MotionInterchange "iPhone SE"
 
 bash <(curl -s https://codecov.io/bash)
+```
+
+## Usage (bazel)
+
+> [Learn more about bazel for iOS](https://docs.bazel.build/versions/master/tutorial/ios-app.html).
+
+An example script making use of the bazel kokoro iOS runner:
+
+```bash
+#!/bin/bash
+
+# Fail on any error.
+set -e
+
+if [ ! -d .kokoro-ios-runner ]; then
+  git clone https://github.com/material-foundation/kokoro-ios-runner.git .kokoro-ios-runner
+fi
+
+pushd .kokoro-ios-runner
+git fetch
+git checkout v1.0.0
+popd
+
+./.kokoro-ios-runner/bazel.sh //:CatalogByConvention
 ```

--- a/bazel.sh
+++ b/bazel.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Copyright 2017-present The Kokoro iOS Runner Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Build script for kokoro.
+#
+# This script will clean, build, and run tests against each installation of Xcode available on the
+# machine using bazel.
+#
+# Arguments:
+#   1. BUILD target.
+#
+# Example usage:
+#   bazel.sh //:CatalogByConvention
+
+# Fail on any error.
+set -e
+
+script_version="v1.0.0"
+echo "bazel_build_and_test version $script_version"
+
+target="$1"
+
+# Dependencies
+
+if [ -z "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
+  : # Local run - nothing to do.
+else
+  # Move into our cloned repo
+  cd github/repo
+fi
+
+# Runs our tests on every available Xcode 8 or 9 installation.
+ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
+  xcode_version=$(cat /Applications/$xcode_path/Contents/version.plist \
+    | grep "CFBundleShortVersionString" -A1 \
+    | grep string \
+    | cut -d'>' -f2 \
+    | cut -d'<' -f1)
+  echo "🏗️  clean building $target with Xcode $xcode_version..."
+  bazel clean
+  bazel build $target --xcode_version $xcode_version
+done

--- a/xcodebuild.sh
+++ b/xcodebuild.sh
@@ -25,7 +25,7 @@
 #   3. grep filter for iPhone simulator types [optional].
 #
 # Example usage:
-#   xcodebuild.sh xcodebuild "MotionInterchange/MotionInterchange.xcodeproj" MotionInterchange "iPhone SE"
+#   xcodebuild.sh "MotionInterchange/MotionInterchange.xcodeproj" MotionInterchange "iPhone SE"
 
 # Fail on any error.
 set -e

--- a/xcodebuild.sh
+++ b/xcodebuild.sh
@@ -25,7 +25,7 @@
 #   3. grep filter for iPhone simulator types [optional].
 #
 # Example usage:
-#   build_and_test "MotionInterchange/MotionInterchange.xcodeproj" MotionInterchange "iPhone SE"
+#   xcodebuild.sh xcodebuild "MotionInterchange/MotionInterchange.xcodeproj" MotionInterchange "iPhone SE"
 
 # Fail on any error.
 set -e


### PR DESCRIPTION
Bazel builds appear to be significantly faster than Carthage and, given that bazel is already installed on kokoro, this will give us a good speed boost in build times.

We'll still need some efficient dependency resolution process across our GitHub repos. I'll explore this in more detail once I deploy this script to a repo that has external dependencies.