### PR TITLE
Use KOKORO_BUILD_NUMBER to detect whether we're building on a kokoro instance rather than KOKORO_GITHUB_PULL_REQUEST_NUMBER

### DIFF
--- a/bazel.sh
+++ b/bazel.sh
@@ -38,7 +38,7 @@ target="$1"
 
 # Dependencies
 
-if [ -z "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
+if [ -z "$KOKORO_BUILD_NUMBER" ]; then
   : # Local run - nothing to do.
 else
   # Move into our cloned repo

--- a/xcodebuild.sh
+++ b/xcodebuild.sh
@@ -74,7 +74,7 @@ run() {
       | xcpretty
       set +o pipefail
 
-      if [ -z "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
+      if [ -z "$KOKORO_BUILD_NUMBER" ]; then
         :
       else
         # Avoid a buildup of active simulators.
@@ -107,7 +107,7 @@ target_simulator_filter="$3"
 
 # Dependencies
 
-if [ -z "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
+if [ -z "$KOKORO_BUILD_NUMBER" ]; then
   : # Local run - nothing to do.
 else
   gem install xcpretty --no-rdoc --no-ri --no-document --quiet
@@ -116,7 +116,7 @@ else
   cd github/repo
 fi
 
-if [ -z "$KOKORO_GITHUB_PULL_REQUEST_NUMBER" ]; then
+if [ -z "$KOKORO_BUILD_NUMBER" ]; then
   run # Run with the Xcode currently pointed to by xcode-select.
 else
   # Runs our tests on every available Xcode 8 or 9 installation.


### PR DESCRIPTION
KOKORO_GITHUB_PULL_REQUEST_NUMBER is only available, rather predictably, during pull requests. This means our test runner doesn't think it's running on kokoro when it runs the continuous build.

Realized this after the CatalogByConfiguration continuous build failed: https://kokoro.corp.google.com/job/CatalogByConvention_iOS/job/macos_external/job/continuous/5/