### PR TITLE
Improved support for unit test runs

### DIFF
--- a/bazel.sh
+++ b/bazel.sh
@@ -77,19 +77,17 @@ ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
     fi
   fi
 
-  set +x
   extra_args=""
   if [ "$action" == "build" ]; then
     echo "🏗️  $target with Xcode $xcode_version..."
   elif [ "$action" == "test" ]; then
     echo "🛠️  $target with Xcode $xcode_version..."
     extra_args="--test_output=errors"
-    
+
     # Resolves the following crash when switching Xcode versions:
     # "Failed to locate a valid instance of CoreSimulatorService in the bootstrap"
     launchctl remove com.apple.CoreSimulator.CoreSimulatorService
   fi
-  set -x
 
   bazel clean
   bazel $action $target --xcode_version $xcode_version $extra_args

--- a/bazel.sh
+++ b/bazel.sh
@@ -52,9 +52,7 @@ min_xcode_version="$(version_as_number $3)"
 
 # Dependencies
 
-if [ -z "$KOKORO_BUILD_NUMBER" ]; then
-  : # Local run - nothing to do.
-else
+if [ -n "$KOKORO_BUILD_NUMBER" ]; then
   # Move into our cloned repo
   cd github/repo
 fi
@@ -66,9 +64,7 @@ ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
     | grep string \
     | cut -d'>' -f2 \
     | cut -d'<' -f1)
-  if [ -z "$min_xcode_version" ]; then
-    :
-  else
+  if [ -n "$min_xcode_version" ]; then
     xcode_version_as_number="$(version_as_number $xcode_version)"
 
     # TODO: This doesn't work yet.
@@ -84,9 +80,14 @@ ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
     echo "🛠️  $target with Xcode $xcode_version..."
     extra_args="--test_output=errors"
 
-    # Resolves the following crash when switching Xcode versions:
-    # "Failed to locate a valid instance of CoreSimulatorService in the bootstrap"
-    launchctl remove com.apple.CoreSimulator.CoreSimulatorService || true
+    if [ -n "$KOKORO_BUILD_NUMBER" ]; then
+      sudo xcode-select --switch /Applications/$xcode_path/Contents/Developer
+      xcodebuild -version
+
+      # Resolves the following crash when switching Xcode versions:
+      # "Failed to locate a valid instance of CoreSimulatorService in the bootstrap"
+      launchctl remove com.apple.CoreSimulator.CoreSimulatorService || true
+    fi
   fi
 
   bazel clean

--- a/bazel.sh
+++ b/bazel.sh
@@ -86,7 +86,9 @@ ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
 
     # Resolves the following crash when switching Xcode versions:
     # "Failed to locate a valid instance of CoreSimulatorService in the bootstrap"
+    set +e
     launchctl remove com.apple.CoreSimulator.CoreSimulatorService
+    set -e
   fi
 
   bazel clean

--- a/bazel.sh
+++ b/bazel.sh
@@ -84,6 +84,10 @@ ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
   elif [ "$action" == "test" ]; then
     echo "🛠️  $target with Xcode $xcode_version..."
     extra_args="--test_output=errors"
+    
+    # Resolves the following crash when switching Xcode versions:
+    # "Failed to locate a valid instance of CoreSimulatorService in the bootstrap"
+    launchctl remove com.apple.CoreSimulator.CoreSimulatorService
   fi
   set -x
 

--- a/bazel.sh
+++ b/bazel.sh
@@ -78,13 +78,15 @@ ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
   fi
 
   set +x
+  extra_args=""
   if [ "$action" == "build" ]; then
     echo "🏗️  $target with Xcode $xcode_version..."
   elif [ "$action" == "test" ]; then
     echo "🛠️  $target with Xcode $xcode_version..."
+    extra_args="--test_output=errors"
   fi
   set -x
 
   bazel clean
-  bazel $action $target --xcode_version $xcode_version
+  bazel $action $target --xcode_version $xcode_version $extra_args
 done

--- a/bazel.sh
+++ b/bazel.sh
@@ -86,9 +86,7 @@ ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
 
     # Resolves the following crash when switching Xcode versions:
     # "Failed to locate a valid instance of CoreSimulatorService in the bootstrap"
-    set +e
-    launchctl remove com.apple.CoreSimulator.CoreSimulatorService
-    set -e
+    launchctl remove com.apple.CoreSimulator.CoreSimulatorService || true
   fi
 
   bazel clean


### PR DESCRIPTION
Also some minor code cleanup (using `-n` instead of `-z` when possible).

I've found that the test runner is most stable when running with a min Xcode version of 8.1.