### PR TITLE
Add more build and test output during bazel runs.

### DIFF
--- a/bazel.sh
+++ b/bazel.sh
@@ -77,7 +77,7 @@ ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
     echo "🏗️  $target with Xcode $xcode_version..."
   elif [ "$action" == "test" ]; then
     echo "🛠️  $target with Xcode $xcode_version..."
-    extra_args="--test_output=errors"
+    extra_args="--test_output=all"
 
     if [ -n "$KOKORO_BUILD_NUMBER" ]; then
       sudo xcode-select --switch /Applications/$xcode_path/Contents/Developer
@@ -90,5 +90,5 @@ ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
   fi
 
   bazel clean
-  bazel $action $target --xcode_version $xcode_version $extra_args
+  bazel $action $target --xcode_version $xcode_version $extra_args -s
 done


### PR DESCRIPTION
`-s` will show the build flags provided to any invocations.

`=all` will show all the executed unit tests, even the passing ones.