### PR TITLE
Add support for passing arbitrary bazel arguments along to bazel

### DIFF
--- a/bazel.sh
+++ b/bazel.sh
@@ -130,9 +130,6 @@ ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
   fi
 
   bazel clean
-  # Build against every cpu first.
-  bazel build $TARGET --xcode_version $xcode_version $extra_args $verbosity_flags $BAZEL_ARGS \
-      --ios_multi_cpus=i386,x86_64
   if [ "$ACTION" -ne "build" ]; then
     bazel $ACTION $TARGET --xcode_version $xcode_version $extra_args $verbosity_flags $BAZEL_ARGS
   fi

--- a/bazel.sh
+++ b/bazel.sh
@@ -30,6 +30,8 @@
 #   -v|--verbose:                     Generates verbose output on local runs.
 #                                     Does not affect kokoro runs.
 #
+# Any other unrecognized arguments will be passed along to the bazel invocation.
+#
 # Example usage:
 #   bazel.sh build //:CatalogByConvention --min-xcode-version 8.2
 #   bazel.sh test //:CatalogByConventionTests -v
@@ -88,6 +90,7 @@ fi
 
 ACTION="$1"
 TARGET="$2"
+BAZEL_ARGS="${@:2}"
 
 # Runs our tests on every available Xcode installation.
 ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
@@ -127,5 +130,5 @@ ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
   fi
 
   bazel clean
-  bazel $ACTION $TARGET --xcode_version $xcode_version $extra_args $verbosity_flags
+  bazel $ACTION $TARGET --xcode_version $xcode_version $extra_args $verbosity_flags $BAZEL_ARGS
 done

--- a/bazel.sh
+++ b/bazel.sh
@@ -90,7 +90,7 @@ fi
 
 ACTION="$1"
 TARGET="$2"
-BAZEL_ARGS="${@:2}"
+BAZEL_ARGS="${POSITIONAL:2}"
 
 # Runs our tests on every available Xcode installation.
 ls /Applications/ | grep "Xcode" | while read -r xcode_path; do

--- a/bazel.sh
+++ b/bazel.sh
@@ -130,7 +130,5 @@ ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
   fi
 
   bazel clean
-  if [ "$ACTION" -ne "build" ]; then
-    bazel $ACTION $TARGET --xcode_version $xcode_version $extra_args $verbosity_flags $BAZEL_ARGS
-  fi
+  bazel $ACTION $TARGET --xcode_version $xcode_version $extra_args $verbosity_flags $BAZEL_ARGS
 done

--- a/bazel.sh
+++ b/bazel.sh
@@ -30,7 +30,7 @@
 #   -v|--verbose:                     Generates verbose output on local runs.
 #                                     Does not affect kokoro runs.
 #
-# Any other unrecognized arguments will be passed along to the bazel invocation.
+# Any unrecognized arguments will be passed along to the bazel invocation.
 #
 # Example usage:
 #   bazel.sh build //:CatalogByConvention --min-xcode-version 8.2

--- a/bazel.sh
+++ b/bazel.sh
@@ -90,7 +90,7 @@ fi
 
 ACTION="$1"
 TARGET="$2"
-BAZEL_ARGS="${@:2}"
+BAZEL_ARGS="${@:3}"
 
 # Runs our tests on every available Xcode installation.
 ls /Applications/ | grep "Xcode" | while read -r xcode_path; do

--- a/bazel.sh
+++ b/bazel.sh
@@ -132,7 +132,7 @@ ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
   bazel clean
   # Build against every cpu first.
   bazel build $TARGET --xcode_version $xcode_version $extra_args $verbosity_flags $BAZEL_ARGS \
-      --ios_multi_cpus=armv7,arm64,i386,x86_64
+      --ios_multi_cpus=i386,x86_64
   if [ "$ACTION" -ne "build" ]; then
     bazel $ACTION $TARGET --xcode_version $xcode_version $extra_args $verbosity_flags $BAZEL_ARGS
   fi

--- a/bazel.sh
+++ b/bazel.sh
@@ -90,7 +90,7 @@ fi
 
 ACTION="$1"
 TARGET="$2"
-BAZEL_ARGS="${POSITIONAL:2}"
+BAZEL_ARGS="${@:2}"
 
 # Runs our tests on every available Xcode installation.
 ls /Applications/ | grep "Xcode" | while read -r xcode_path; do

--- a/bazel.sh
+++ b/bazel.sh
@@ -130,5 +130,10 @@ ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
   fi
 
   bazel clean
-  bazel $ACTION $TARGET --xcode_version $xcode_version $extra_args $verbosity_flags $BAZEL_ARGS
+  # Build against every cpu first.
+  bazel build $TARGET --xcode_version $xcode_version $extra_args $verbosity_flags $BAZEL_ARGS \
+      --ios_multi_cpus=armv7,arm64,i386,x86_64
+  if [ "$ACTION" -ne "build" ]; then
+    bazel $ACTION $TARGET --xcode_version $xcode_version $extra_args $verbosity_flags $BAZEL_ARGS
+  fi
 done


### PR DESCRIPTION
This will allow us to scalably provide arguments to bazel over time. Most notably, we'd like to be able to customize the cpus being built against using `--ios_multi_cpus=i386,x86_64`.