### PR TITLE
Use array expansion to add extra bazel args to the bazel invocation.

### DIFF
--- a/bazel.sh
+++ b/bazel.sh
@@ -130,5 +130,5 @@ ls /Applications/ | grep "Xcode" | while read -r xcode_path; do
   fi
 
   bazel clean
-  bazel $ACTION $TARGET --xcode_version $xcode_version $extra_args $verbosity_flags $BAZEL_ARGS
+  bazel $ACTION $TARGET --xcode_version $xcode_version $extra_args $verbosity_flags "${POSITIONAL[@]:2}"
 done

--- a/bazel.sh
+++ b/bazel.sh
@@ -90,7 +90,6 @@ fi
 
 ACTION="$1"
 TARGET="$2"
-BAZEL_ARGS="${@:3}"
 
 # Runs our tests on every available Xcode installation.
 ls /Applications/ | grep "Xcode" | while read -r xcode_path; do


### PR DESCRIPTION
This is necessary for cases when arguments are passed that involve quotation, such as `"--ios_simulator_device=iPad Pro (12.9-inch)"`. If we store the extra args as a string, then when we expand it in the bazel invocation the string will be parsed as a string literal or as a whitespace-delimited array of arguments, which can cause the original argument quotations to be lost or changed. By expanding the arguments as an array, we honor the original quotations of the arguments.

This will resolve the bug encountered in https://github.com/material-components/material-components-ios/pull/2470#pullrequestreview-77501114.